### PR TITLE
nginx1.7.4: using "-Werror"

### DIFF
--- a/src/ngx_http_mongo_module.c
+++ b/src/ngx_http_mongo_module.c
@@ -678,15 +678,12 @@ static ngx_chain_t *
 ngx_http_mongo_create_predefined_request(ngx_http_request_t *r, ngx_int_t id,
     ngx_int_t flush)
 {
-    ngx_http_mongo_ctx_t  *mctx;
     ngx_chain_t           *cl, *head;
     ngx_buf_t             *b;
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "mongo: create predefined request: \"%V\" (flush: %d)",
                    &ngx_http_mongo_predefined[id].json, flush);
-
-    mctx = ngx_http_get_module_ctx(r, ngx_http_mongo_module);
 
     /* header */
     cl = ngx_http_mongo_create_header(r, &ngx_http_mongo_opcodes[0],


### PR DESCRIPTION
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/os/unix -I objs -I src/http -I src/http/modules -I src/mail \
        -o objs/addon/src/ngx_http_mongo_module.o \
        ./ngx_mongo//src/ngx_http_mongo_module.c
./ngx_mongo//src/ngx_http_mongo_module.c: In function ‘ngx_http_mongo_create_predefined_request’:
./ngx_mongo//src/ngx_http_mongo_module.c:681:28: error: variable ‘mctx’ set but not used [-Werror=unused-but-set-variable]
     ngx_http_mongo_ctx_t  _mctx;
                            ^
cc1: all warnings being treated as errors
make[1]: *_\* [objs/addon/src/ngx_http_mongo_module.o] Error 1
make[1]: Leaving directory `/usr/src/nginx-1.7.4'
make: **\* [build] Error 2
